### PR TITLE
Dev v1.6.0

### DIFF
--- a/ADVANCED_USAGE.md
+++ b/ADVANCED_USAGE.md
@@ -10,7 +10,7 @@ The file must be named `.jelloconf.py` and must be located in the proper directo
 
 ##### Setting Options
 To set `jello` options in the `.jelloconf.py` file, import the `jello.lib.opts` class, add any of the following and set to `True` or `False`:
-```
+```python
 from jello.lib import opts
 opts.mono = True            # -m option
 opts.compact = True         # -c option
@@ -22,7 +22,7 @@ opts.types = True           # -t option
 ```
 ##### Setting Colors
 You can customize the colors by importing the `jello.lib.opts` class and setting the following variables to one of the following string values: `'black'`, `'red'`, `'green'`, `'yellow'`, `'blue'`, `'magenta'`, `'cyan'`, `'gray'`, `'brightblack'`, `'brightred'`, `'brightgreen'`, `'brightyellow'`, `'brightblue'`, `'brightmagenta'`, `'brightcyan'`, or `'white'`.
-```
+```python
 from jello.lib import opts
 opts.keyname_color = 'blue'            # Key names
 opts.keyword_color = 'brightblack'     # true, false, null
@@ -33,7 +33,7 @@ opts.string_color = 'green'            # strings
 
 ##### Importing Modules
 To import a module (e.g. `glom`) during initialization, just add the `import` statement to your `.jelloconf.py` file:
-```
+```python
 from glom import *
 ```
 Then you can use `glom` in your `jello` filters without importing:
@@ -44,10 +44,10 @@ jc -a | jello -i 'glom(_, "parsers.25.name")'
 
 ##### Adding Functions
 You can also add functions to your initialization file.  For example, you could simplify `glom` use by adding the following function to `.jelloconf.py`:
-```
-def g(q, data=_):
+```python
+def g(query):
     import glom
-    return glom.glom(data, q)
+    return glom.glom(_, query)
 ```
 
 Then you can use the following syntax to filter the JSON data:
@@ -60,6 +60,28 @@ jc -a | jello -i 'g("parsers.6.compatible")'
   "win32",
   "aix",
   "freebsd"
+]
+```
+
+Or you can predefine often-used queries by defining them as functions in `.jelloconf.py`:
+```python
+def darwin_compatible():
+    result = []
+    for entry in _.parsers:
+      if "darwin" in entry.compatible:
+        result.append(entry.name)
+    return result
+```
+
+Then you can use the predefined query like so:
+```bash
+jc -a | jello -i 'darwin_compatible()'
+[
+  "airport",
+  "airport_s",
+  "arp",
+  "asciitable",
+  ...
 ]
 ```
 

--- a/ADVANCED_USAGE.md
+++ b/ADVANCED_USAGE.md
@@ -85,4 +85,8 @@ jc -a | jello -i 'darwin_compatible()'
 ]
 ```
 
-> Tip: Add a line to print a message to STDERR in your `.jelloconf.py` file to show when the initialization file is being used: `print('Running initialization file', file=sys.stderr)`
+Tip: Add a the following to print a message to STDERR in your `.jelloconf.py` file to show when the initialization file is being used:
+```python
+import sys
+print('Running initialization file', file=sys.stderr)
+```

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@ jello changelog
 
 20230423 v1.6.0
 - Add the ability to directly use a JSON file or JSON Lines files as data input (`-f`)
-- Add the ability to run a query from a file (`-q`)
+- Add the ability to load a query from a file (`-q`)
 - Add the empty data option (`-e`)
 - Fix user-defined functions in ~/.jelloconf initialization file
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 jello changelog
 
+20230423 v1.6.0
+- Add the ability to directly use a JSON file or JSON Lines files as data input (`-f`)
+- Add the ability to run a query from a file (`-q`)
+- Add the empty data option (`-e`)
+- Fix user-defined functions in ~/.jelloconf initialization file
+
 20230114 v1.5.5
 - Fix schema output to ensure invalid variable names are enclosed in bracket notation
 - Fix to allow blank lines when slurping JSON Lines objects

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Filter JSON and JSON Lines data with Python syntax
 
 `jello` is similar to `jq` in that it processes JSON and JSON Lines data except `jello` uses standard python dict and list syntax.
 
-JSON or JSON Lines can be piped into `jello` via STDIN or can be loaded from a JSON file or JSON Lines files (JSON Lines are automatically slurped into a list of dictionaries). Once loaded, the data is available as an object named '`_`'. Processed data can be output as JSON, JSON Lines, bash array lines, or a grep-able schema.
+JSON or JSON Lines can be piped into `jello` via STDIN or can be loaded from a JSON file or JSON Lines files (JSON Lines are automatically slurped into a list of dictionaries). Once loaded, the data is available as a python list or dictionary object named '`_`'. Processed data can be output as JSON, JSON Lines, bash array lines, or a grep-able schema.
 
 For more information on the motivations for this project, see my [blog post](https://blog.kellybrazil.com/2020/03/25/jello-the-jq-alternative-for-pythonistas/).
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Filter JSON and JSON Lines data with Python syntax
 
 `jello` is similar to `jq` in that it processes JSON and JSON Lines data except `jello` uses standard python dict and list syntax.
 
-JSON or JSON Lines can be piped into `jello` (JSON Lines are automatically slurped into a list of dictionaries) and are available as the variable `_`. Processed data can be output as JSON, JSON Lines, bash array lines, or a grep-able schema.
+JSON or JSON Lines can be piped into `jello` via STDIN or can be loaded from a JSON file or JSON Lines files (JSON Lines are automatically slurped into a list of dictionaries). Once loaded, the data is available as an object named '`_`'. Processed data can be output as JSON, JSON Lines, bash array lines, or a grep-able schema.
 
 For more information on the motivations for this project, see my [blog post](https://blog.kellybrazil.com/2020/03/25/jello-the-jq-alternative-for-pythonistas/).
 
@@ -41,9 +41,12 @@ See [Releases](https://github.com/kellyjonbrazil/jello/releases) on Github for M
 
 ### Usage
 ```
-cat data.json | jello [OPTIONS] [QUERY]
+cat data.json | jello [OPTIONS] [QUERY | -q <query_file>]
+
+jello [OPTIONS] [QUERY | -q <query_file>] [-f <input_files>]
 ```
-`QUERY` is optional and can be most any valid python code. `_` is the sanitized JSON from STDIN presented as a python dict or list of dicts. If `QUERY` is omitted then the original JSON input will simply be pretty printed. You can use dot notation or traditional python bracket notation to access key names.
+`QUERY` is optional and can be most any valid python code. Alternatively, a
+query file can be specified with `-q` to load the query from a file. Within the query, `_` is the sanitized JSON from STDIN presented as a python dict or list of dicts. If `QUERY` is omitted then the original JSON input will simply be pretty printed. You can use dot notation or traditional python bracket notation to access key names.
 
 > Note: Reserved key names that cannot be accessed using dot notation can be accessed via standard python dictionary notation. (e.g. `_.foo["get"]` instead of `_.foo.get`)
 
@@ -53,16 +56,23 @@ cat data.json | jello _.foo
 ```
 or
 ```bash
-cat data.json | jello '_["foo"]'
+jello _.foo -f data.json
+```
+or
+```bash
+jello '_["foo"]' -f data.json
 ```
 
 #### Options
 - `-c` compact print JSON output instead of pretty printing
 - `-C` force color output even when using pipes (overrides `-m` and the `NO_COLOR` env variable)
+- `-e` empty data (don't process data from STDIN or file)
+- `-f` load input data from JSON file or JSON Lines files (must be the final option, if used)
 - `-i` initialize environment with a custom config file
 - `-l` lines output (suitable for bash array assignment)
 - `-m` monochrome output
 - `-n` print selected `null` values
+- `-q` load query from a file
 - `-r` raw output of selected strings (no quotes)
 - `-s` print the JSON schema in grep-able format
 - `-t` print type annotations in schema view

--- a/jello/__init__.py
+++ b/jello/__init__.py
@@ -1,7 +1,7 @@
 """jello - query JSON at the command line with python syntax"""
 
 
-__version__ = '1.5.5'
+__version__ = '1.6.0'
 AUTHOR = 'Kelly Brazil'
 WEBSITE = 'https://github.com/kellyjonbrazil/jello'
 COPYRIGHT = '© 2020-2023 Kelly Brazil'

--- a/jello/cli.py
+++ b/jello/cli.py
@@ -134,7 +134,7 @@ def main(data=None, query='_'):
             try:
                 query = read_file(arg)
             except Exception as e:
-                print_error(f'Issue reading query file: {e}')
+                print_error(f'jello:  Issue reading query file: {e}')
             finally:
                 arg_section = ''
 
@@ -142,7 +142,7 @@ def main(data=None, query='_'):
             try:
                 data += '\n' + read_file(arg)
             except Exception as e:
-                print_error(f'Issue reading data file: {e}')
+                print_error(f'jello:  Issue reading data file: {e}')
 
         elif arg.startswith('-') and not arg.startswith('--'):
              options.extend(arg[1:])

--- a/jello/cli.py
+++ b/jello/cli.py
@@ -27,7 +27,8 @@ def print_help():
     print(textwrap.dedent('''\
         jello:  query JSON at the command line with python syntax
 
-        Usage:  cat data.json | jello [OPTIONS] [QUERY]
+        Usage:  cat data.json | jello [OPTIONS] [QUERY | -q <query_file>]
+                jello [OPTIONS] [QUERY | -q <query_file>] [-f <input_files>]
 
                 -c   compact JSON output
                 -C   force color output even when using pipes (overrides -m)

--- a/jello/cli.py
+++ b/jello/cli.py
@@ -140,11 +140,9 @@ def main(data=None, query='_'):
 
         elif arg_section == 'data_files':
             try:
-                data += read_file(arg)
+                data += '\n' + read_file(arg)
             except Exception as e:
                 print_error(f'Issue reading data file: {e}')
-            finally:
-                arg_section = ''
 
         elif arg.startswith('-') and not arg.startswith('--'):
              options.extend(arg[1:])

--- a/jello/cli.py
+++ b/jello/cli.py
@@ -31,11 +31,14 @@ def print_help():
 
                 -c   compact JSON output
                 -C   force color output even when using pipes (overrides -m)
+                -e   empty data (don't process data from STDIN or file)
+                -f   load input data from JSON file or JSON Lines files
                 -i   initialize environment with .jelloconf.py
                      located at ~ (linux) or %appdata% (Windows)
                 -l   output as lines suitable for assignment to a bash array
                 -m   monochrome output
                 -n   print selected null values
+                -q   load query from a file
                 -r   raw string output (no quotes)
                 -s   print the JSON schema in grep-able format
                 -t   print type annotations in schema view
@@ -47,7 +50,8 @@ def print_help():
 
         Examples:
                 cat data.json | jello _.foo
-                cat data.json | jello '_["foo"]'
+                jello _.foo -f data.json
+                jello '_["foo"]' -f data.json
                 variable=($(cat data.json | jello -l _.foo))
     '''))
     sys.exit()
@@ -120,7 +124,7 @@ def main(data=None, query='_'):
 
     options = []
     long_options = {}
-    arg_section = ''  # query_file or data_files
+    arg_section = ''  # can be query_file or data_files
 
     for arg in sys.argv[1:]:
         if arg == '-q':
@@ -163,6 +167,7 @@ def main(data=None, query='_'):
     opts.compact = opts.compact or 'c' in options
     opts.initialize = opts.initialize or 'i' in options
     opts.lines = opts.lines or 'l' in options
+    opts.empty = opts.empty or 'e' in options
     opts.force_color = opts.force_color or 'C' in options
     opts.mono = opts.mono or ('m' in options or bool(os.getenv('NO_COLOR')))
     opts.nulls = opts.nulls or 'n' in options
@@ -185,52 +190,52 @@ def main(data=None, query='_'):
         '''))
         sys.exit()
 
-    if data is None:
-        print_error('jello:  missing piped JSON or JSON Lines data\n')
+    if data is None and not opts.empty:
+        print_error('jello:  Missing JSON or JSON Lines data via STDIN or file via -f option.\n')
 
-    # only process if there is data
-    if data and not data.isspace():
+    if opts.empty:
+        data = '{}'
 
-        # load the JSON or JSON Lines into a dict or list of dicts
-        try:
-            data = load_json(data)
-        except Exception as e:
-            print_exception(e, ex_type='JSON Load')
+    # load the JSON or JSON Lines into a dict or list of dicts
+    try:
+        data = load_json(data)
+    except Exception as e:
+        print_exception(e, ex_type='JSON Load')
 
-        # Read .jelloconf.py (if it exists) and run the query
-        response = ''
-        try:
-            response = pyquery(data, query)
-        except Exception as e:
-            print_exception(e, data, query, ex_type='Query')
+    # Read .jelloconf.py (if it exists) and run the query
+    response = ''
+    try:
+        response = pyquery(data, query)
+    except Exception as e:
+        print_exception(e, data, query, ex_type='Query')
 
-        # reset opts.mono after pyquery since initialization in pyquery can change values
-        if opts.force_color:
-            opts.mono = False
+    # reset opts.mono after pyquery since initialization in pyquery can change values
+    if opts.force_color:
+        opts.mono = False
 
-        # Create and print schema or JSON/JSON-Lines/Lines
-        output = ''
-        try:
-            if opts.schema:
-                schema = Schema()
-                output = schema.create_schema(response)
+    # Create and print schema or JSON/JSON-Lines/Lines
+    output = ''
+    try:
+        if opts.schema:
+            schema = Schema()
+            output = schema.create_schema(response)
 
-                if not opts.mono and (sys.stdout.isatty() or opts.force_color):
-                    schema.set_colors()
-                    output = schema.color_output(output)
+            if not opts.mono and (sys.stdout.isatty() or opts.force_color):
+                schema.set_colors()
+                output = schema.color_output(output)
 
-            else:
-                json_out = Json()
-                output = json_out.create_json(response)
+        else:
+            json_out = Json()
+            output = json_out.create_json(response)
 
-                if (not opts.mono and not opts.raw) and (sys.stdout.isatty() or opts.force_color):
-                    json_out.set_colors()
-                    output = json_out.color_output(output)
+            if (not opts.mono and not opts.raw) and (sys.stdout.isatty() or opts.force_color):
+                json_out.set_colors()
+                output = json_out.color_output(output)
 
-            print(output)
+        print(output)
 
-        except Exception as e:
-            print_exception(e, data, query, response, ex_type='Output')
+    except Exception as e:
+        print_exception(e, data, query, response, ex_type='Output')
 
 
 if __name__ == '__main__':

--- a/jello/lib.py
+++ b/jello/lib.py
@@ -411,7 +411,7 @@ def pyquery(data, query):
     # read initialization file to set colors, options, and user-defined functions
     jelloconf = ''
     conf_file = ''
-    jcnf_dict = None
+    jcnf_dict = {}
 
     if opts.initialize:
         pyquery._ = _  # allows the data to be available to the initialization file
@@ -471,8 +471,7 @@ def pyquery(data, query):
 
     # add any functions in initialization file to the scope
     scope = {'_': _, 'os': os}
-    if jcnf_dict:
-        scope.update(jcnf_dict)
+    scope.update(jcnf_dict)
 
     # run the query
     block = ast.parse(query, mode='exec')

--- a/jello/lib.py
+++ b/jello/lib.py
@@ -391,6 +391,9 @@ def warning_message(message_lines):
         message = next_wrapper.fill(line)
         print(message, file=sys.stderr)
 
+def read_file(file_path):
+    with open(file_path, 'r') as f:
+        return f.read()
 
 def pyquery(data, query):
     """Sets options and runs the user's query."""
@@ -423,8 +426,7 @@ def pyquery(data, query):
 
         try:
             conf_file = os.path.join(conf_file_dir, '.jelloconf.py')
-            with open(conf_file, 'r') as f:
-                jelloconf = f.read()
+            jelloconf = read_file(conf_file)
 
             # inject the data into the initialization module
             conf_prepend = 'from jello.lib import pyquery as __q__\n'

--- a/jello/lib.py
+++ b/jello/lib.py
@@ -44,6 +44,7 @@ class opts:
     version_info = None
     helpme = None
     compact = None
+    empty = None
     nulls = None
     raw = None
     lines = None

--- a/jello/lib.py
+++ b/jello/lib.py
@@ -408,14 +408,14 @@ def pyquery(data, query):
     else:
         _ = data
 
-    pyquery._ = _  # allows the data to be available to the initialization file, if used
-
     # read initialization file to set colors, options, and user-defined functions
     jelloconf = ''
     conf_file = ''
     jcnf_dict = None
 
     if opts.initialize:
+        pyquery._ = _  # allows the data to be available to the initialization file
+
         if sys.platform.startswith('win32'):
             conf_file_dir = os.environ['APPDATA']
         else:

--- a/man/jello.1
+++ b/man/jello.1
@@ -435,16 +435,6 @@ You can also add functions to your initialization file. For example, you could s
 def g(query):
     import glom
     return glom.glom(_, query)
-
-or
-
-def darwin_compatible():
-    result = []
-    for entry in _.parsers:
-      if "darwin" in entry.compatible:
-        result.append(entry.name)
-    return result
-\f[R]
 .fi
 .PP
 Then you can use the following syntax to filter the JSON data:
@@ -460,7 +450,23 @@ $ jc -a | jello -i \[aq]g(\[dq]parsers.6.compatible\[dq])\[aq]
   \[dq]aix\[dq],
   \[dq]freebsd\[dq]
 ]
-
+.fi
+.PP
+Or create names for commonly used queries:
+.IP
+.nf
+def darwin_compatible():
+    result = []
+    for entry in _.parsers:
+      if "darwin" in entry.compatible:
+        result.append(entry.name)
+    return result
+\f[R]
+.fi
+.PP
+Then use the predefined query like so:
+.IP
+.nf
 $ jc -a | jello -i \[aq]darwin_compatible()\[aq]
 [
   \[dq]airport\[dq],

--- a/man/jello.1
+++ b/man/jello.1
@@ -1,4 +1,4 @@
-.TH jello 1 2022-06-26 1.5.3 "Jello JSON Filter"
+.TH jello 1 2022-06-26 1.6.0 "Jello JSON Filter"
 .SH NAME
 Jello \- Filter JSON and JSON Lines data with Python syntax
 .SH SYNOPSIS
@@ -16,15 +16,23 @@ grep-able schema.
 
 .SH USAGE
 
-cat data.json | jello [OPTIONS] [QUERY]
+.RS
+cat data.json | jello [OPTIONS] [QUERY | -q <query_file>]
+
+jello [OPTIONS] [QUERY | -q <query_file>] [-f <input_files>]
+.RE
 
 .fi
 .PP
-QUERY is optional and can be most any valid python code.
-`\fB_\fP` is the sanitized JSON from \fBSTDIN\fP presented as a python dict
-or list of dicts.
-If QUERY is omitted then the original JSON input will simply
+QUERY is optional and can be most any valid python code. Alternatively, a
+query file can be specified with `\fB-q\fP` to load the query from a file.
+Within the query, `\fB_\fP` is the sanitized JSON from \fBSTDIN\fP or the
+specified input file(s) (via the `\fB-f\fP` option) presented as a python
+dict or list of dicts.
+
+If QUERY or a query file is omitted then the original JSON input will simply
 be pretty printed.
+
 You can use dot notation or traditional python bracket notation to
 access key names.
 .RS
@@ -50,11 +58,23 @@ or
 $ cat data.json | jello \[aq]_[\[dq]foo\[dq]]\[aq]
 
 .fi
+.PP
+or
+.IP
+.nf
+
+$ jello _.foo -f data.json
+
+.fi
 .SS Options
 .IP
 \fB-c\fP compact print JSON output instead of pretty printing
 .IP
 \fB-C\fP force color output even when using pipes (overrides \fB-m\fP and the \fBNO_COLOR\fP env variable)
+.IP
+\fB-e\fP empty data (don't process data from STDIN or file)
+.IP
+\fB-f\fP load input data from JSON file or JSON Lines files
 .IP
 \fB-i\fP initialize environment with a custom config file
 .IP
@@ -63,6 +83,8 @@ $ cat data.json | jello \[aq]_[\[dq]foo\[dq]]\[aq]
 \fB-m\fP monochrome output
 .IP
 \fB-n\fP print selected null values
+.IP
+\fB-q\fP load query from a file
 .IP
 \fB-r\fP raw output of selected strings (no quotes)
 .IP
@@ -410,9 +432,18 @@ You can also add functions to your initialization file. For example, you could s
 .IP
 .nf
 \f[C]
-def g(q, data=_):
+def g(query):
     import glom
-    return glom.glom(data, q)
+    return glom.glom(_, query)
+
+or
+
+def darwin_compatible():
+    result = []
+    for entry in _.parsers:
+      if "darwin" in entry.compatible:
+        result.append(entry.name)
+    return result
 \f[R]
 .fi
 .PP
@@ -428,6 +459,13 @@ $ jc -a | jello -i \[aq]g(\[dq]parsers.6.compatible\[dq])\[aq]
   \[dq]win32\[dq],
   \[dq]aix\[dq],
   \[dq]freebsd\[dq]
+]
+
+$ jc -a | jello -i \[aq]darwin_compatible()\[aq]
+[
+  \[dq]airport\[dq],
+  \[dq]airport-s\[dq],
+  \[dq]arp\[dq]
 ]
 \f[R]
 .fi
@@ -477,6 +515,6 @@ Kelly Brazil (kellyjonbrazil@gmail.com)
 https://github.com/kellyjonbrazil/jello
 
 .SH COPYRIGHT
-Copyright (c) 2020-2022 Kelly Brazil
+Copyright (c) 2020-2023 Kelly Brazil
 
 License: MIT License

--- a/man/jello.1
+++ b/man/jello.1
@@ -74,7 +74,7 @@ $ jello _.foo -f data.json
 .IP
 \fB-e\fP empty data (don't process data from STDIN or file)
 .IP
-\fB-f\fP load input data from JSON file or JSON Lines files
+\fB-f\fP load input data from JSON file or JSON Lines files (must be the final option, if used)
 .IP
 \fB-i\fP initialize environment with a custom config file
 .IP

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as f:
 
 setuptools.setup(
     name='jello',
-    version='1.5.5',
+    version='1.6.0',
     author='Kelly Brazil',
     author_email='kellyjonbrazil@gmail.com',
     description='Filter JSON and JSON Lines data with Python syntax.',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3696,5 +3696,24 @@ foods = set(f.name for f in _.foods)
         self.assertEqual(f.getvalue(), expected)
 
 
+    def test_initialization_file(self):
+
+        # patch read_file function to mock initialization file
+        old_read_file = jello.lib.read_file
+        jello.lib.read_file = lambda x: 'init_var = "test"'
+
+        sample = '''{"a": "hello world"}'''
+        expected = '"test"\n'
+
+        f = io.StringIO()
+        with contextlib.redirect_stdout(f):
+            testargs = ['jello', '-i', 'init_var']
+            with patch.object(sys, 'argv', testargs):
+                _ = jello.cli.main(data=sample)
+
+        jello.lib.read_file = old_read_file
+        self.assertEqual(f.getvalue(), expected)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Add the ability to directly use a JSON file or JSON Lines files as data input (`-f`)
- Add the ability to load a query from a file (`-q`)
- Add the empty data option (`-e`)
- Fix user-defined functions in `~/.jelloconf` initialization file