### PR TITLE
add optional add_to_scope argument to pyquery()

### DIFF
--- a/jello/lib.py
+++ b/jello/lib.py
@@ -396,7 +396,7 @@ def read_file(file_path):
     with open(file_path, 'r') as f:
         return f.read()
 
-def pyquery(data, query):
+def pyquery(data, query, add_to_scope=None):
     """Sets options and runs the user's query."""
     output = None
 
@@ -475,6 +475,8 @@ def pyquery(data, query):
     # add any functions in initialization file to the scope
     scope = {'_': _, 'os': os}
     scope.update(jcnf_dict)
+    if add_to_scope is not None:
+        scope.update(add_to_scope)
 
     # run the query
     block = ast.parse(query, mode='exec')


### PR DESCRIPTION
This allows to insert additional variables into the scope the jello query runs in.

This is helpful for example when using jello as Jinja/Ansible filter and you want to access other variables like facts or the inventory.

Does not affect running jello on the commandline, only usable when calling the jello module from other python programs.

This is something I mentioned in https://github.com/kellyjonbrazil/jello/discussions/57#discussioncomment-5716128

Here is an example how this could be used (in the context of using jello as an ansible filter as in the discussion linked):
```
    - name: convert local ip to network interface name
      set_fact:
        interface_out: "{{ ip_to_check | jello(ip_to_interface_q) }}"
      vars:
        ip_to_interface_q: |
          result = ""
          for interface in ctx['ansible_facts']['interfaces']:
            if 'ipv4' in ctx['ansible_facts'][interface]:
              if ctx['ansible_facts'][interface]['ipv4']['address'] == _:
                result = interface
          result
```
